### PR TITLE
fix(chain): returning the signedTx's Hash

### DIFF
--- a/output/chain/eth/tx.go
+++ b/output/chain/eth/tx.go
@@ -65,5 +65,5 @@ func SendTX(ctx context.Context, endpoint, privateKey, toStr string, data []byte
 		return "", errors.Wrap(err, "send transaction failed")
 	}
 
-	return tx.Hash().Hex(), nil
+	return signedTx.Hash().Hex(), nil
 }


### PR DESCRIPTION
The reason why hash returned by `SendTx` cannot be found on blockchain is that it returns the hash of raw transaction instead of a signed transaction