### PR TITLE
feat(output):  Add Output Result

### DIFF
--- a/output/adapter/ethereum.go
+++ b/output/adapter/ethereum.go
@@ -33,13 +33,20 @@ const (
 ]`
 )
 
-// EthereumContract is the adapter for outputting proofs to an ethereum-compatible contract
-type EthereumContract struct {
-	chainEndpoint   string
-	contractAddress string
-	secretKey       string
-	contractABI     abi.ABI
-}
+type (
+	// EthereumContract is the adapter for outputting proofs to an ethereum-compatible contract
+	EthereumContract struct {
+		chainEndpoint   string
+		contractAddress string
+		secretKey       string
+		contractABI     abi.ABI
+	}
+
+	// EthereumContractResult is the result of the ethereum contract adapter
+	EthereumContractResult struct {
+		TxHash string
+	}
+)
 
 // NewEthereumContract returns a new ethereum contract adapter
 func NewEthereumContract(chainEndpoint, secretKey, contractAddress string) (*EthereumContract, error) {
@@ -56,19 +63,19 @@ func NewEthereumContract(chainEndpoint, secretKey, contractAddress string) (*Eth
 }
 
 // Output outputs the proof to the ethereum contract
-func (e *EthereumContract) Output(proof []byte) error {
+func (e *EthereumContract) Output(proof []byte) (Result, error) {
 	// pack contract data
 	data, err := e.contractABI.Pack(contractMethod, proof)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// send tx
 	txHash, err := eth.SendTX(context.Background(), e.chainEndpoint, e.secretKey, e.contractAddress, data)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	slog.Debug("ethereum contract output", "txHash", txHash)
 
-	return nil
+	return &EthereumContractResult{TxHash: txHash}, nil
 }

--- a/output/adapter/result.go
+++ b/output/adapter/result.go
@@ -1,0 +1,4 @@
+package adapter
+
+// Result is the result of the output adapter
+type Result interface{}

--- a/output/adapter/solana.go
+++ b/output/adapter/solana.go
@@ -9,13 +9,20 @@ import (
 	"github.com/machinefi/sprout/output/chain/solana"
 )
 
-// SolanaProgram is the solana program adapter
-type SolanaProgram struct {
-	endpoint       string
-	programID      string
-	secretKey      string
-	stateAccountPK string
-}
+type (
+	// SolanaProgram is the solana program adapter
+	SolanaProgram struct {
+		endpoint       string
+		programID      string
+		secretKey      string
+		stateAccountPK string
+	}
+
+	// SolanaProgramResult is the result of the solana program adapter
+	SolanaProgramResult struct {
+		TxHash string
+	}
+)
 
 // NewSolanaProgram returns a new solana program adapter
 func NewSolanaProgram(endpoint, programID, secretKey, stateAccountPK string) *SolanaProgram {
@@ -28,18 +35,18 @@ func NewSolanaProgram(endpoint, programID, secretKey, stateAccountPK string) *So
 }
 
 // Output outputs the proof to the ethereum contract
-func (e *SolanaProgram) Output(proof []byte) error {
+func (e *SolanaProgram) Output(proof []byte) (Result, error) {
 	// pack instructions
 	ins := e.packInstructions(proof)
 
 	// send tx
 	txHash, err := solana.SendTX(e.endpoint, e.secretKey, ins)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	slog.Debug("solana contract output", "txHash", txHash)
 
-	return nil
+	return &SolanaProgramResult{TxHash: txHash}, nil
 }
 
 // encodeData encodes the proof into the data field of the instruction

--- a/output/adapter/stdout.go
+++ b/output/adapter/stdout.go
@@ -14,7 +14,7 @@ func NewStdout() *Stdout {
 }
 
 // Output writes the proof to stdout.
-func (r *Stdout) Output(proof []byte) error {
+func (r *Stdout) Output(proof []byte) (Result, error) {
 	slog.Info("stdout", "proof", hex.EncodeToString(proof))
-	return nil
+	return "", nil
 }

--- a/output/outputter.go
+++ b/output/outputter.go
@@ -10,7 +10,7 @@ type (
 	// Outputter is the interface for outputting proofs
 	Outputter interface {
 		// Output outputs the proof
-		Output(proof []byte) error
+		Output(proof []byte) (adapter.Result, error)
 	}
 )
 


### PR DESCRIPTION
Add a `Result` return value to the output interface to store the processing result, facilitating user observation and usage.