### PR TITLE
feat(output): Replace Endpoint with ChainName

### DIFF
--- a/output/chain/chain.go
+++ b/output/chain/chain.go
@@ -1,0 +1,56 @@
+package chain
+
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+)
+
+// Chain names
+const (
+	IoTeXTestNet  Name = "iotex-testnet"
+	SolanaTestNet Name = "solana-testnet"
+)
+
+type (
+	// Name is the name of the chain
+	Name string
+
+	// Chain is the chain configuration
+	Chain struct {
+		Name     Name   `json:"name"`
+		ID       uint64 `json:"chainID"`
+		Endpoint string `json:"endpoint"`
+	}
+)
+
+var (
+	supportedChains = []Name{
+		IoTeXTestNet,
+		SolanaTestNet,
+	}
+)
+
+// ChainsFromJSON parses the chain config from json
+func ChainsFromJSON(data []byte) (map[Name]Chain, error) {
+	// parse the chains
+	chains := make([]Chain, 0)
+	if err := json.Unmarshal(data, &chains); err != nil {
+		return nil, err
+	}
+
+	// convert to map
+	chainMap := make(map[Name]Chain)
+	for _, chain := range chains {
+		chainMap[chain.Name] = chain
+	}
+
+	// check if all supported chains are present
+	for _, name := range supportedChains {
+		if _, ok := chainMap[name]; !ok {
+			return nil, errors.Errorf("missing chain config:%s", name)
+		}
+	}
+
+	return chainMap, nil
+}

--- a/output/chain/chain_test.go
+++ b/output/chain/chain_test.go
@@ -1,0 +1,31 @@
+package chain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestChainsFromJSON(t *testing.T) {
+	r := require.New(t)
+
+	jsonData := []byte(`[
+		{
+			"name": "iotex-testnet",
+			"chainID": 4690,
+			"endpoint": "endpoint"
+		},
+		{
+			"name": "solana-testnet",
+			"endpoint": "endpointsolana"
+		}
+	]`)
+	chains, err := ChainsFromJSON(jsonData)
+	r.NoError(err)
+	r.Len(chains, 2)
+	r.EqualValues(chains[IoTeXTestNet].Name, IoTeXTestNet)
+	r.EqualValues(chains[IoTeXTestNet].ID, uint64(4690))
+	r.EqualValues(chains[IoTeXTestNet].Endpoint, "endpoint")
+	r.EqualValues(chains[SolanaTestNet].Name, SolanaTestNet)
+	r.EqualValues(chains[SolanaTestNet].Endpoint, "endpointsolana")
+}

--- a/output/config.go
+++ b/output/config.go
@@ -1,25 +1,42 @@
 package output
 
+import "github.com/machinefi/sprout/output/chain"
+
 type (
 	// Config is the configuration for the outputter
 	Config struct {
-		Type Type
-
-		// for the ethereum & solana contract outputter
-		ChainEndpoint   string
+		Type            Type
+		ChainName       chain.Name
 		ContractAddress string
 		SecretKey       string
-		// for the solana program outputter
-		StateAccountPK string
+		StateAccountPK  string
 	}
-
-	// Type is the type of outputter
-	Type string
 )
 
-// Types of outputters
-const (
-	Stdout           Type = "stdout"
-	EthereumContract Type = "ethereumContract"
-	SolanaProgram    Type = "solanaProgram"
-)
+// NewStdoutConfig creates a stdout config
+func NewStdoutConfig() Config {
+	return Config{
+		Type: Stdout,
+	}
+}
+
+// NewEthereumContractConfig creates an ethereum contract config
+func NewEthereumContractConfig(chainName chain.Name, contractAddress, secretKey string) Config {
+	return Config{
+		Type:            EthereumContract,
+		ChainName:       chainName,
+		ContractAddress: contractAddress,
+		SecretKey:       secretKey,
+	}
+}
+
+// NewSolanaProgramConfig creates a solana program config
+func NewSolanaProgramConfig(chainName chain.Name, programID, secretKey, stateAccountPK string) Config {
+	return Config{
+		Type:            SolanaProgram,
+		ChainName:       chainName,
+		ContractAddress: programID,
+		SecretKey:       secretKey,
+		StateAccountPK:  stateAccountPK,
+	}
+}

--- a/output/outputter.go
+++ b/output/outputter.go
@@ -1,28 +1,62 @@
 package output
 
 import (
-	"errors"
-
 	"github.com/machinefi/sprout/output/adapter"
+	"github.com/machinefi/sprout/output/chain"
+	"github.com/pkg/errors"
+)
+
+// Types of outputters
+const (
+	Stdout           Type = "stdout"
+	EthereumContract Type = "ethereumContract"
+	SolanaProgram    Type = "solanaProgram"
 )
 
 type (
+	// Type is the type of outputter
+	Type string
+
 	// Outputter is the interface for outputting proofs
 	Outputter interface {
 		// Output outputs the proof
 		Output(proof []byte) error
 	}
+
+	// Factory is the factory for creating outputters
+	Factory struct {
+		chains map[chain.Name]chain.Chain
+	}
 )
 
+// NewFactory creates a new outputter factory
+func NewFactory(chainConfig []byte) (*Factory, error) {
+	chains, err := chain.ChainsFromJSON(chainConfig)
+	if err != nil {
+		return nil, err
+	}
+	return &Factory{
+		chains: chains,
+	}, nil
+}
+
 // NewOutputter returns a new outputter based on the config
-func NewOutputter(cfg Config) (out Outputter, err error) {
+func (f *Factory) NewOutputter(cfg Config) (out Outputter, err error) {
 	switch cfg.Type {
 	case Stdout:
 		out = adapter.NewStdout()
 	case EthereumContract:
-		out, err = adapter.NewEthereumContract(cfg.ChainEndpoint, cfg.SecretKey, cfg.ContractAddress)
+		chain, ok := f.chains[cfg.ChainName]
+		if !ok {
+			return nil, errors.Errorf("invalid chain name: %s", cfg.ChainName)
+		}
+		out, err = adapter.NewEthereumContract(chain.Endpoint, cfg.SecretKey, cfg.ContractAddress)
 	case SolanaProgram:
-		out = adapter.NewSolanaProgram(cfg.ChainEndpoint, cfg.ContractAddress, cfg.SecretKey, cfg.StateAccountPK)
+		chain, ok := f.chains[cfg.ChainName]
+		if !ok {
+			return nil, errors.Errorf("invalid chain name: %s", cfg.ChainName)
+		}
+		out = adapter.NewSolanaProgram(chain.Endpoint, cfg.ContractAddress, cfg.SecretKey, cfg.StateAccountPK)
 	default:
 		return nil, errors.New("invalid output type")
 	}


### PR DESCRIPTION
Now, when using the output module, it is no longer necessary to specify the endpoint. Instead, you first need to configure the supported chain list when creating the `Factory` object, and then specify the chain name when creating the specific outputer.